### PR TITLE
Rename class 'Object' into 'ObjectClass' because Object is a reserved…

### DIFF
--- a/demo/js/transformer.js
+++ b/demo/js/transformer.js
@@ -6520,7 +6520,7 @@ exports.moonwalk = function moonwalk(ast, fn){
         items.push(encodeString(keyName));
         items.push(this.generate(node.value));
       }, this);
-      return 'new Object(' + items.join(', ') + ')';
+      return 'new ObjectClass(' + items.join(', ') + ')';
     },
 
     CallExpression: function(node) {
@@ -6922,7 +6922,7 @@ exports.moonwalk = function moonwalk(ast, fn){
       return 'null';
     }
     if (type === 'null') {
-      return 'Object::$null';
+      return 'ObjectClass::$null';
     }
     if (type === 'string') {
       return encodeString(value);

--- a/php/classes/Array.php
+++ b/php/classes/Array.php
@@ -1,5 +1,5 @@
 <?php
-class Arr extends Object {
+class Arr extends ObjectClass {
   public $className = "Array";
   public $length = 0;
 
@@ -214,7 +214,7 @@ Arr::$protoMethods = array(
       $len = $self->length;
       for ($i = 0; $i < $len; $i++) {
         $value = $self->get($i);
-        $results[] = ($value === null || $value === Object::$null) ? '' : to_string($value);
+        $results[] = ($value === null || $value === ObjectClass::$null) ? '' : to_string($value);
       }
       return join(to_string($str), $results);
     },
@@ -476,6 +476,6 @@ Arr::$protoMethods = array(
     }
 );
 
-Arr::$protoObject = new Object();
+Arr::$protoObject = new ObjectClass();
 Arr::$protoObject->setMethods(Arr::$protoMethods, true, false, true);
 Arr::$empty = new StdClass();

--- a/php/classes/Boolean.php
+++ b/php/classes/Boolean.php
@@ -1,5 +1,5 @@
 <?php
-class Bln extends Object {
+class Bln extends ObjectClass {
   public $className = "Boolean";
   public $value = null;
 
@@ -51,5 +51,5 @@ Bln::$protoMethods = array(
     }
 );
 
-Bln::$protoObject = new Object();
+Bln::$protoObject = new ObjectClass();
 Bln::$protoObject->setMethods(Bln::$protoMethods, true, false, true);

--- a/php/classes/Buffer.php
+++ b/php/classes/Buffer.php
@@ -1,5 +1,5 @@
 <?php
-class Buffer extends Object {
+class Buffer extends ObjectClass {
 
   public $raw = '';
   public $length = 0;
@@ -227,5 +227,5 @@ Buffer::$protoMethods = array(
     }
 );
 
-Buffer::$protoObject = new Object();
+Buffer::$protoObject = new ObjectClass();
 Buffer::$protoObject->setMethods(Buffer::$protoMethods, true, false, true);

--- a/php/classes/Date.php
+++ b/php/classes/Date.php
@@ -1,5 +1,5 @@
 <?php
-class Date extends Object {
+class Date extends ObjectClass {
   public $className = "Date";
   /* @var DateTime - date object; second accuracy only; "local" timezone */
   public $date = null;
@@ -307,7 +307,7 @@ Date::$protoMethods = array(
     }
 );
 
-Date::$protoObject = new Object();
+Date::$protoObject = new ObjectClass();
 Date::$protoObject->setMethods(Date::$protoMethods, true, false, true);
 
 //get the local timezone by looking for environment variable; fallback to constant and then UTC

--- a/php/classes/Error.php
+++ b/php/classes/Error.php
@@ -1,5 +1,5 @@
 <?php
-class Err extends Object {
+class Err extends ObjectClass {
   public $className = "Error";
   public $stack = null;
 
@@ -72,5 +72,5 @@ Err::$protoMethods = array(
     }
 );
 
-Err::$protoObject = new Object();
+Err::$protoObject = new ObjectClass();
 Err::$protoObject->setMethods(Err::$protoMethods, true, false, true);

--- a/php/classes/Exception.php
+++ b/php/classes/Exception.php
@@ -59,7 +59,7 @@ class Ex extends Exception {
       $fn($output);
     }
     //an exception could be thrown before we have initialized $console
-    if (isset($console) && ($console instanceof Object)) {
+    if (isset($console) && ($console instanceof ObjectClass)) {
       $console->callMethod('log', $output);
     } else {
       echo $output;
@@ -83,7 +83,7 @@ class Ex extends Exception {
           $list[] = ($arg) ? 'true' : 'false';
         } else if (is_object($arg)) {
           $class = get_class($arg);
-          if ($arg instanceof Object) {
+          if ($arg instanceof ObjectClass) {
             $constructor = $arg->get('constructor');
             if ($constructor instanceof Func && $constructor->name) {
               $class .= '[' . $constructor->name . ']';

--- a/php/classes/Function.php
+++ b/php/classes/Function.php
@@ -1,5 +1,5 @@
 <?php
-class Func extends Object {
+class Func extends ObjectClass {
   public $name = "";
   public $className = "Function";
 
@@ -25,7 +25,7 @@ class Func extends Object {
 
   /**
    * Instantiate is an optional method that can be specified if calling `new` on
-   * this function should instantiate a different `this` than `new Object()`
+   * this function should instantiate a different `this` than `new ObjectClass()`
    * @var callable
    */
   public $instantiate = null;
@@ -47,7 +47,7 @@ class Func extends Object {
     $this->fn = array_shift($args);
     $this->meta = isset($args[0]) ? $args[0] : array();
     $this->strict = isset($this->meta['strict']);
-    $prototype = new Object();
+    $prototype = new ObjectClass();
     $prototype->setProp('constructor', $this, true, false, true);
     $this->setProp('prototype', $prototype, true, false, true);
     $this->setProp('name', $this->name, false, false, false);
@@ -57,7 +57,7 @@ class Func extends Object {
     if ($this->instantiate !== null) {
       $obj = call_user_func($this->instantiate);
     } else {
-      $obj = new Object();
+      $obj = new ObjectClass();
       $obj->proto = $this->get('prototype');
     }
     $result = $this->apply($obj, func_get_args());
@@ -77,9 +77,9 @@ class Func extends Object {
     }
     $this->args = $args;
     if (!$this->strict) {
-      if ($context === null || $context === Object::$null) {
-        $context = Object::$global;
-      } else if (!($context instanceof Object)) {
+      if ($context === null || $context === ObjectClass::$null) {
+        $context = ObjectClass::$global;
+      } else if (!($context instanceof ObjectClass)) {
         //primitives (boolean, number, string) should be wrapped in object
         $context = objectify($context);
       }
@@ -175,7 +175,7 @@ class Func extends Object {
   }
 }
 
-class Args extends Object {
+class Args extends ObjectClass {
   /* @var array */
   public $args = null;
   /* @var int */
@@ -271,8 +271,8 @@ Func::$protoMethods = array(
     }
 );
 
-Func::$protoObject = new Object();
+Func::$protoObject = new ObjectClass();
 Func::$protoObject->setMethods(Func::$protoMethods, true, false, true);
 
 //set the methods on Object.prototype before we proceed
-Object::$protoObject->setMethods(Object::$protoMethods, true, false, true);
+ObjectClass::$protoObject->setMethods(ObjectClass::$protoMethods, true, false, true);

--- a/php/classes/Global.php
+++ b/php/classes/Global.php
@@ -1,5 +1,5 @@
 <?php
-class GlobalObject extends Object {
+class GlobalObject extends ObjectClass {
   public $className = "global";
 
   //disallow mutating pre-defined globals
@@ -50,7 +50,7 @@ class GlobalObject extends Object {
       return true;
     }
     $proto = $this->proto;
-    if ($proto instanceof Object) {
+    if ($proto instanceof ObjectClass) {
       return $proto->hasProperty($key);
     }
     return false;
@@ -75,7 +75,7 @@ class GlobalObject extends Object {
       }
     }
     $proto = $this->proto;
-    if ($proto instanceof Object) {
+    if ($proto instanceof ObjectClass) {
       $proto->getKeys($arr);
     }
     return $arr;
@@ -126,4 +126,4 @@ class GlobalObject extends Object {
 }
 
 GlobalObject::unsetGlobals();
-Object::$global = new GlobalObject();
+ObjectClass::$global = new GlobalObject();

--- a/php/classes/Number.php
+++ b/php/classes/Number.php
@@ -1,5 +1,5 @@
 <?php
-class Number extends Object {
+class Number extends ObjectClass {
   public $className = "Number";
   public $value = null;
 
@@ -127,5 +127,5 @@ Number::$protoMethods = array(
     }
 );
 
-Number::$protoObject = new Object();
+Number::$protoObject = new ObjectClass();
 Number::$protoObject->setMethods(Number::$protoMethods, true, false, true);

--- a/php/classes/ObjectClass.php
+++ b/php/classes/ObjectClass.php
@@ -1,5 +1,5 @@
 <?php
-class Object {
+class ObjectClass {
   public $data = array();
   /* @var Descriptor[] */
   public $dscr = array();
@@ -43,7 +43,7 @@ class Object {
       return $this->{'get_' . $key}();
     }
     $obj = $this;
-    while ($obj !== Object::$null) {
+    while ($obj !== ObjectClass::$null) {
       if (array_key_exists($key, $obj->data)) {
         return $obj->data[$key];
       }
@@ -91,7 +91,7 @@ class Object {
       return true;
     }
     $proto = $this->proto;
-    if ($proto instanceof Object) {
+    if ($proto instanceof ObjectClass) {
       return $proto->hasProperty($key);
     }
     return false;
@@ -124,7 +124,7 @@ class Object {
       }
     }
     $proto = $this->proto;
-    if ($proto instanceof Object) {
+    if ($proto instanceof ObjectClass) {
       $proto->getKeys($arr);
     }
     return $arr;
@@ -242,14 +242,14 @@ class Object {
    */
   static function getGlobalConstructor() {
     $Object = new Func(function($value = null) {
-      if ($value === null || $value === Object::$null) {
-        return new Object();
+      if ($value === null || $value === ObjectClass::$null) {
+        return new ObjectClass();
       } else {
         return objectify($value);
       }
     });
-    $Object->set('prototype', Object::$protoObject);
-    $Object->setMethods(Object::$classMethods, true, false, true);
+    $Object->set('prototype', ObjectClass::$protoObject);
+    $Object->setMethods(ObjectClass::$classMethods, true, false, true);
     return $Object;
   }
 }
@@ -266,10 +266,10 @@ class Descriptor {
   }
 
   /**
-   * @return Object
+   * @return ObjectClass
    */
   function toObject($value = null) {
-    $result = new Object();
+    $result = new ObjectClass();
     $result->set('value', $value);
     $result->set('writable', $this->writable);
     $result->set('enumerable', $this->enumerable);
@@ -278,34 +278,34 @@ class Descriptor {
   }
 
   static function getDefault($value = null) {
-    return new Object('value', $value, 'writable', true, 'enumerable', true, 'configurable', true);
+    return new ObjectClass('value', $value, 'writable', true, 'enumerable', true, 'configurable', true);
   }
 }
 
-Object::$classMethods = array(
+ObjectClass::$classMethods = array(
   //todo: getPrototypeOf, seal, freeze, preventExtensions, isSealed, isFrozen, isExtensible
   'create' => function($proto) {
-      if (!($proto instanceof Object) && $proto !== Object::$null) {
+      if (!($proto instanceof ObjectClass) && $proto !== ObjectClass::$null) {
         throw new Ex(Err::create('Object prototype may only be an Object or null'));
       }
-      $obj = new Object();
+      $obj = new ObjectClass();
       $obj->proto = $proto;
       return $obj;
     },
   'keys' => function($obj) {
-      if (!($obj instanceof Object)) {
+      if (!($obj instanceof ObjectClass)) {
         throw new Ex(Err::create('Object.keys called on non-object'));
       }
       return Arr::fromArray($obj->getOwnKeys(true));
     },
   'getOwnPropertyNames' => function($obj) {
-      if (!($obj instanceof Object)) {
+      if (!($obj instanceof ObjectClass)) {
         throw new Ex(Err::create('Object.getOwnPropertyNames called on non-object'));
       }
       return Arr::fromArray($obj->getOwnKeys(false));
     },
   'getOwnPropertyDescriptor' => function($obj, $key) {
-      if (!($obj instanceof Object)) {
+      if (!($obj instanceof ObjectClass)) {
         throw new Ex(Err::create('Object.getOwnPropertyDescriptor called on non-object'));
       }
       $key = (string)$key;
@@ -326,7 +326,7 @@ Object::$classMethods = array(
     },
   'defineProperty' => function($obj, $key, $desc) {
       $key = (string)$key;
-      if (!($obj instanceof Object)) {
+      if (!($obj instanceof ObjectClass)) {
         throw new Ex(Err::create('Object.defineProperty called on non-object'));
       }
       $writable = $desc->get('writable');
@@ -380,13 +380,13 @@ Object::$classMethods = array(
       }
     },
   'defineProperties' => function($obj, $items) {
-      if (!($obj instanceof Object)) {
+      if (!($obj instanceof ObjectClass)) {
         throw new Ex(Err::create('Object.defineProperties called on non-object'));
       }
-      if (!($items instanceof Object)) {
+      if (!($items instanceof ObjectClass)) {
         throw new Ex(Err::create('Object.defineProperties called with invalid list of properties'));
       }
-      $defineProperty = Object::$classMethods['defineProperty'];
+      $defineProperty = ObjectClass::$classMethods['defineProperty'];
       foreach ($items->data as $key => $value) {
         $dscr = isset($items->dscr[$key]) ? $items->dscr[$key] : null;
         if (!$dscr || $dscr->enumerable) {
@@ -423,7 +423,7 @@ Object::$classMethods = array(
     }
 );
 
-Object::$protoMethods = array(
+ObjectClass::$protoMethods = array(
   'hasOwnProperty' => function($key) {
       $self = Func::getContext();
       //this should implicitly ensure $key is a string
@@ -433,7 +433,7 @@ Object::$protoMethods = array(
       $self = Func::getContext();
       if ($self === null) {
         $className = 'Undefined';
-      } else if ($self === Object::$null) {
+      } else if ($self === ObjectClass::$null) {
         $className = 'Null';
       } else {
         $obj = objectify($self);
@@ -448,7 +448,7 @@ Object::$protoMethods = array(
 
 class NullClass {}
 
-Object::$null = new NullClass();
+ObjectClass::$null = new NullClass();
 //the methods are not set on Object.prototype until *after* Func class is defined
-Object::$protoObject = new Object();
-Object::$protoObject->proto = Object::$null;
+ObjectClass::$protoObject = new ObjectClass();
+ObjectClass::$protoObject->proto = ObjectClass::$null;

--- a/php/classes/RegExp.php
+++ b/php/classes/RegExp.php
@@ -1,5 +1,5 @@
 <?php
-class RegExp extends Object {
+class RegExp extends ObjectClass {
   public $className = "RegExp";
 
   public $source = '';
@@ -128,7 +128,7 @@ RegExp::$protoMethods = array(
         throw new Ex(Err::create('Error executing Regular Expression: ' . $self->toString()));
       }
       if ($result === 0) {
-        return Object::$null;
+        return ObjectClass::$null;
       }
       $index = $matches[0][1];
       $self->set('lastIndex', (float)($index + strlen($matches[0][0])));
@@ -151,5 +151,5 @@ RegExp::$protoMethods = array(
     }
 );
 
-RegExp::$protoObject = new Object();
+RegExp::$protoObject = new ObjectClass();
 RegExp::$protoObject->setMethods(RegExp::$protoMethods, true, false, true);

--- a/php/classes/String.php
+++ b/php/classes/String.php
@@ -1,5 +1,5 @@
 <?php
-class Str extends Object {
+class Str extends ObjectClass {
   public $className = "String";
   public $value = null;
 
@@ -322,5 +322,5 @@ Str::$protoMethods = array(
     }
 );
 
-Str::$protoObject = new Object();
+Str::$protoObject = new ObjectClass();
 Str::$protoObject->setMethods(Str::$protoMethods, true, false, true);

--- a/php/globals/JSON.php
+++ b/php/globals/JSON.php
@@ -3,7 +3,7 @@ $JSON = call_user_func(function() {
 
   $decode = function($value) use (&$decode) {
     if ($value === null) {
-      return Object::$null;
+      return ObjectClass::$null;
     }
     $type = gettype($value);
     if ($type === 'integer') {
@@ -18,7 +18,7 @@ $JSON = call_user_func(function() {
         $result->push($decode($item));
       }
     } else {
-      $result = new Object();
+      $result = new ObjectClass();
       foreach ($value as $key => $item) {
         if ($key === '_empty_') {
           $key = '';
@@ -34,7 +34,7 @@ $JSON = call_user_func(function() {
   };
 
   $encode = function($parent, $key, $value, $opts, $encodeNull = false) use (&$escape, &$encode) {
-    if ($value instanceof Object) {
+    if ($value instanceof ObjectClass) {
       //todo: flatten boxed primitive (use toJSON?)
       //class may specify its own toJSON (date/buffer)
       if (method_exists($value, 'toJSON')) {
@@ -55,7 +55,7 @@ $JSON = call_user_func(function() {
       return $encodeNull ? 'null' : $value;
     }
     //todo: handle same as above?
-    if ($value === Object::$null || $value === INF || $value === -INF) {
+    if ($value === ObjectClass::$null || $value === INF || $value === -INF) {
       return 'null';
     }
     $type = gettype($value);
@@ -138,12 +138,12 @@ $JSON = call_user_func(function() {
         $opts->replacer = ($replacer instanceof Func) ? $replacer : null;
         $opts->level = -1.0;
         // dummy object required if we have a replacer function (see json2 implementation)
-        $obj = ($opts->replacer !== null) ? new Object('', $value) : null;
+        $obj = ($opts->replacer !== null) ? new ObjectClass('', $value) : null;
         return $encode($obj, '', $value, $opts);
       }
   );
 
-  $JSON = new Object();
+  $JSON = new ObjectClass();
   $JSON->setMethods($methods, true, false, true);
   // expose for use elsewhere in php-land
   $JSON->fromNative = $decode;

--- a/php/globals/Math.php
+++ b/php/globals/Math.php
@@ -112,7 +112,7 @@ $Math = call_user_func(function() {
     'SQRT2' => M_SQRT2
   );
 
-  $Math = new Object();
+  $Math = new ObjectClass();
   $Math->setMethods($methods, true, false, true);
   $Math->setProps($constants, true, false, true);
 

--- a/php/globals/console.php
+++ b/php/globals/console.php
@@ -5,7 +5,7 @@ $console = call_user_func(function() {
   $stderr = defined('STDERR') ? STDERR : null;
 
   $toString = function($value) {
-    if ($value instanceof Object) {
+    if ($value instanceof ObjectClass) {
       if (class_exists('Debug')) {
         //should be ok to call the underlying function directly
         return call_user_func(Debug::$inspect->fn, $value);
@@ -15,14 +15,14 @@ $console = call_user_func(function() {
         $toString = $value->get('toString');
       }
       if (!($toString instanceof Func)) {
-        $toString = Object::$protoObject->get('toString');
+        $toString = ObjectClass::$protoObject->get('toString');
       }
       return $toString->call($value);
     }
     return to_string($value);
   };
 
-  $console = new Object();
+  $console = new ObjectClass();
 
   $console->set('log', new Func(function() use (&$stdout, &$toString) {
     if ($stdout === null) {

--- a/php/globals/globals.php
+++ b/php/globals/globals.php
@@ -1,10 +1,10 @@
 <?php
-$global = Object::$global;
+$global = ObjectClass::$global;
 $undefined = null;
 $Infinity = INF;
 $NaN = NAN;
 
-$Object = Object::getGlobalConstructor();
+$Object = ObjectClass::getGlobalConstructor();
 $Function = Func::getGlobalConstructor();
 $Array = Arr::getGlobalConstructor();
 $Boolean = Bln::getGlobalConstructor();

--- a/php/globals/process.php
+++ b/php/globals/process.php
@@ -1,5 +1,5 @@
 <?php
-$process = new Object();
+$process = new ObjectClass();
 
 // the type of interface between web server and PHP
 $process->set('sapi_name', php_sapi_name());

--- a/php/helpers/Debug.php
+++ b/php/helpers/Debug.php
@@ -327,7 +327,7 @@ var inspect = (function() {
 //this is generated from JS; loosely based on inspect module from Node.js
 Debug::$inspect = call_user_func(function() use (&$Date, &$Object, &$RegExp, &$JSON, &$Error, &$String, &$Array) {
   $inspect = new Func("inspect", function($obj = null, $depth = null) use (&$stylizeNoColor, &$formatValue) {
-    $ctx = new Object("seen", new Arr(), "stylize", $stylizeNoColor);
+    $ctx = new ObjectClass("seen", new Arr(), "stylize", $stylizeNoColor);
     return call($formatValue, $ctx, $obj, (isset($depth) ? _typeof($depth) : "undefined") === "undefined" ? 2.0 : $depth);
   });
   $stylizeNoColor = new Func("stylizeNoColor", function($str = null, $styleType = null) {
@@ -416,7 +416,7 @@ Debug::$inspect = call_user_func(function() use (&$Date, &$Object, &$RegExp, &$J
       case "boolean":
         return call_method($ctx, "stylize", _concat("", $value), "boolean");
     }
-    if ($value === Object::$null) {
+    if ($value === ObjectClass::$null) {
       return call_method($ctx, "stylize", "null", "null");
     }
   });
@@ -441,13 +441,13 @@ Debug::$inspect = call_user_func(function() use (&$Date, &$Object, &$RegExp, &$J
     return $output;
   });
   $formatProperty = new Func("formatProperty", function($ctx = null, $value = null, $recurseTimes = null, $keys = null, $key = null, $array = null) use (&$formatValue, &$JSON) {
-    $desc = new Object("value", get($value, $key));
+    $desc = new ObjectClass("value", get($value, $key));
     if (call_method($keys, "indexOf", $key) < 0.0) {
       $name = _concat("[", $key, "]");
     }
     if (call_method(get($ctx, "seen"), "indexOf", get($desc, "value")) < 0.0) {
-      if ($recurseTimes === Object::$null) {
-        $str = call($formatValue, $ctx, get($desc, "value"), Object::$null);
+      if ($recurseTimes === ObjectClass::$null) {
+        $str = call($formatValue, $ctx, get($desc, "value"), ObjectClass::$null);
       } else {
         $str = call($formatValue, $ctx, get($desc, "value"), to_number($recurseTimes) - 1.0);
       }

--- a/php/helpers/Module.php
+++ b/php/helpers/Module.php
@@ -37,7 +37,7 @@ class Module {
   }
 
   /**
-   * @param Object $obj
+   * @param ObjectClass $obj
    */
   static function eventify($obj) {
     $obj->set('on', self::$on);
@@ -50,7 +50,7 @@ Module::$on = new Func(function($name, $listener) {
   $self = Func::getContext();
   $events = $self->get('_events');
   if ($events === null) {
-    $events = new Object();
+    $events = new ObjectClass();
     $self->set('_events', $events);
   }
   $listeners = $events->get($name);

--- a/php/helpers/helpers.php
+++ b/php/helpers/helpers.php
@@ -8,7 +8,7 @@
  * @return bool
  */
 function is($x) {
-  return $x !== false && $x !== 0.0 && $x !== '' && $x !== null && $x !== Object::$null && $x === $x /* NaN check */;
+  return $x !== false && $x !== 0.0 && $x !== '' && $x !== null && $x !== ObjectClass::$null && $x === $x /* NaN check */;
 }
 
 /**
@@ -17,7 +17,7 @@ function is($x) {
  * @return bool
  */
 function not($x) {
-  return $x === false || $x === 0.0 || $x === '' || $x === null || $x === Object::$null || $x !== $x /* NaN check */;
+  return $x === false || $x === 0.0 || $x === '' || $x === null || $x === ObjectClass::$null || $x !== $x /* NaN check */;
 }
 
 /**
@@ -28,8 +28,8 @@ function not($x) {
  * @return bool
  */
 function eq($a, $b) {
-  $typeA = ($a === null || $a === Object::$null ? 'null' : ($a instanceof Object ? 'object' : gettype($a)));
-  $typeB = ($b === null || $b === Object::$null ? 'null' : ($b instanceof Object ? 'object' : gettype($b)));
+  $typeA = ($a === null || $a === ObjectClass::$null ? 'null' : ($a instanceof ObjectClass ? 'object' : gettype($a)));
+  $typeB = ($b === null || $b === ObjectClass::$null ? 'null' : ($b instanceof ObjectClass ? 'object' : gettype($b)));
   if ($typeA === 'null' && $typeB === 'null') {
     return true;
   }
@@ -67,19 +67,19 @@ function eq($a, $b) {
 
 /**
  * Used in `for..in` to get keys (including up the proto chain)
- * @param Object $obj
+ * @param ObjectClass $obj
  * @param array $arr
  * @return array
  */
 function keys($obj, &$arr = array()) {
-  if (!($obj instanceof Object)) {
+  if (!($obj instanceof ObjectClass)) {
     return $arr;
   }
   return $obj->getKeys($arr);
 }
 
 function is_primitive($value) {
-  return ($value === null || $value === Object::$null || is_scalar($value));
+  return ($value === null || $value === ObjectClass::$null || is_scalar($value));
 }
 
 function is_int_or_float($value) {
@@ -90,7 +90,7 @@ function to_string($value) {
   if ($value === null) {
     return 'undefined';
   }
-  if ($value === Object::$null) {
+  if ($value === ObjectClass::$null) {
     return 'null';
   }
   $type = gettype($value);
@@ -106,7 +106,7 @@ function to_string($value) {
     if ($value === -INF) return '-Infinity';
     return $value . '';
   }
-  if ($value instanceof Object) {
+  if ($value instanceof ObjectClass) {
     $fn = $value->get('toString');
     if ($fn instanceof Func) {
       return $fn->call($value);
@@ -121,7 +121,7 @@ function to_number($value) {
   if ($value === null) {
     return NAN;
   }
-  if ($value === Object::$null) {
+  if ($value === ObjectClass::$null) {
     return 0.0;
   }
   if (is_float($value)) {
@@ -133,7 +133,7 @@ function to_number($value) {
   if (is_bool($value)) {
     return ($value ? 1.0 : 0.0);
   }
-  if ($value instanceof Object) {
+  if ($value instanceof ObjectClass) {
     return to_number(to_primitive($value));
   }
   //trim whitespace
@@ -161,12 +161,12 @@ function to_number($value) {
 
 /**
  * Used in to_number/eq to handle objects
- * @param Object $obj
+ * @param ObjectClass $obj
  * @return mixed
  */
 function to_primitive($obj) {
   $value = $obj->callMethod('valueOf');
-  if ($value instanceof Object) {
+  if ($value instanceof ObjectClass) {
     $value = to_string($value);
   }
   return $value;
@@ -175,7 +175,7 @@ function to_primitive($obj) {
 /**
  * Used to get/set properties on primitives
  * @param $value
- * @return Object
+ * @return ObjectClass
  */
 function objectify($value) {
   $type = gettype($value);
@@ -194,13 +194,13 @@ function objectify($value) {
 
 /**
  * get a property from a primitive or Object
- * @param null|string|float|bool|Object|Null $obj
+ * @param null|string|float|bool|ObjectClass|Null $obj
  * @param string $name
  * @return mixed
  * @throws Exception
  */
 function get($obj, $name) {
-  if ($obj === null || $obj === Object::$null) {
+  if ($obj === null || $obj === ObjectClass::$null) {
     throw new Ex(Err::create("Cannot read property '" . $name . "' of " . to_string($obj)));
   }
   $obj = objectify($obj);
@@ -210,7 +210,7 @@ function get($obj, $name) {
 /**
  * Set a property on a primitive or Object (setting on a primitive would
  * normally be useless). The operator specified can be =, +=, *=, etc.
- * @param null|string|float|bool|Object|Null $obj
+ * @param null|string|float|bool|ObjectClass|Null $obj
  * @param string $name
  * @param $value
  * @param string $op
@@ -219,7 +219,7 @@ function get($obj, $name) {
  * @throws Exception
  */
 function set($obj, $name, $value, $op = '=', $returnOld = false) {
-  if ($obj === null || $obj === Object::$null) {
+  if ($obj === null || $obj === ObjectClass::$null) {
     throw new Ex(Err::create("Cannot set property '" . $name . "' of " . to_string($obj)));
   }
   $obj = objectify($obj);
@@ -260,17 +260,17 @@ function call($fn) {
     throw new Ex(Err::create(_typeof($fn) . " is not a function"));
   }
   $args = array_slice(func_get_args(), 1);
-  return $fn->apply(Object::$global, $args);
+  return $fn->apply(ObjectClass::$global, $args);
 }
 
 /**
- * @param Object $obj
+ * @param ObjectClass $obj
  * @param string $name
  * @return mixed
  * @throws Exception
  */
 function call_method($obj, $name) {
-  if ($obj === null || $obj === Object::$null) {
+  if ($obj === null || $obj === ObjectClass::$null) {
     throw new Ex(Err::create("Cannot read property '" . $name . "' of " . to_string($obj)));
   }
   $obj = objectify($obj);

--- a/php/helpers/operators.php
+++ b/php/helpers/operators.php
@@ -6,7 +6,7 @@ function _void() {
 
 /**
  * @param Func $fn
- * @return Object
+ * @return ObjectClass
  * @throws Exception
  */
 function _new($fn) {
@@ -18,12 +18,12 @@ function _new($fn) {
 }
 
 /**
- * @param Object $obj
+ * @param ObjectClass $obj
  * @param Func $fn
  * @return bool
  */
 function _instanceof($obj, $fn) {
-  if (!($obj instanceof Object)) {
+  if (!($obj instanceof ObjectClass)) {
     return false;
   }
   if (!($fn instanceof Func)) {
@@ -31,7 +31,7 @@ function _instanceof($obj, $fn) {
   }
   $proto = $obj->proto;
   $prototype = get($fn, 'prototype');
-  while ($proto !== Object::$null) {
+  while ($proto !== ObjectClass::$null) {
     if ($proto === $prototype) {
       return true;
     }
@@ -97,7 +97,7 @@ function _delete($obj, $key = null) {
   if (func_num_args() === 1) {
     return false;
   }
-  if ($obj === null || $obj === Object::$null) {
+  if ($obj === null || $obj === ObjectClass::$null) {
     throw new Ex(Err::create("Cannot convert undefined or null to object"));
   }
   $obj = objectify($obj);
@@ -107,12 +107,12 @@ function _delete($obj, $key = null) {
 
 /**
  * @param string $key
- * @param Object $obj
+ * @param ObjectClass $obj
  * @return bool
  * @throws Exception
  */
 function _in($key, $obj) {
-  if (!($obj instanceof Object)) {
+  if (!($obj instanceof ObjectClass)) {
     throw new Ex(Err::create("Cannot use 'in' operator to search for '" . $key . "' in " . to_string($obj)));
   }
   return $obj->hasProperty($key);
@@ -123,7 +123,7 @@ function _typeof($value) {
     return 'undefined';
   }
   //js weirdness
-  if ($value === Object::$null) {
+  if ($value === ObjectClass::$null) {
     return 'object';
   }
   $type = gettype($value);
@@ -136,7 +136,7 @@ function _typeof($value) {
   if ($value instanceof Func) {
     return 'function';
   }
-  if ($value instanceof Object) {
+  if ($value instanceof ObjectClass) {
     return 'object';
   }
   return 'unknown';

--- a/php/modules/fs.php
+++ b/php/modules/fs.php
@@ -7,7 +7,7 @@ Module::define('fs', function() {
     $self = Func::getContext();
     $fullPath = $helpers['mapPath']($path);
     $self->set('path', $fullPath);
-    $opts = ($opts instanceof Object) ? $opts : new Object();
+    $opts = ($opts instanceof ObjectClass) ? $opts : new ObjectClass();
     $self->set('opts', $opts);
     if (!$opts->hasOwnProperty('chunkSize')) {
       $opts->set('chunkSize', $CHUNK_SIZE);
@@ -24,7 +24,7 @@ Module::define('fs', function() {
     $self->stream = $stream;
   });
 
-  /* @var Object $prototype */
+  /* @var ObjectClass $prototype */
   $prototype = $ReadStream->get('prototype');
   Module::eventify($prototype);
   $prototype->setMethods(array(
@@ -81,7 +81,7 @@ Module::define('fs', function() {
     $self = Func::getContext();
     $fullPath = $helpers['mapPath']($path);
     $self->set('path', $fullPath);
-    $opts = ($opts instanceof Object) ? $opts : new Object();
+    $opts = ($opts instanceof ObjectClass) ? $opts : new ObjectClass();
     $self->set('opts', $opts);
     //default is to append
     $append = $opts->get('append') !== false;
@@ -201,7 +201,7 @@ Module::define('fs', function() {
       },
     'createDir' => function($path, $opts = null) use (&$helpers) {
         $fullPath = $helpers['mapPath']($path);
-        $opts = ($opts instanceof Object) ? $opts : new Object();
+        $opts = ($opts instanceof ObjectClass) ? $opts : new ObjectClass();
         $mode = $helpers['normalizeMode']($opts->get('mode'), 0777);
         $deep = ($opts->get('deep') === true);
         try {
@@ -292,7 +292,7 @@ Module::define('fs', function() {
       },
     'writeFile' => function($path, $data, $opts = null) use (&$helpers) {
         $fullPath = $helpers['mapPath']($path);
-        $opts = ($opts instanceof Object) ? $opts : new Object();
+        $opts = ($opts instanceof ObjectClass) ? $opts : new ObjectClass();
         //default is to append
         $append = $opts->get('append') !== false;
         //overwrite option will override append
@@ -414,7 +414,7 @@ Module::define('fs', function() {
           $helpers['throwError']('EIO', $fullPath);
         }
         $isDir = is_dir($fullPath);
-        $result = new Object();
+        $result = new ObjectClass();
         $result->set('name', basename($fullPath));
         $result->set('dateCreated', new Date($stat['ctime'] * 1000));
         $result->set('dateLastAccessed', new Date($stat['atime'] * 1000));
@@ -490,7 +490,7 @@ Module::define('fs', function() {
       }
   );
 
-  $fs = new Object();
+  $fs = new ObjectClass();
   $fs->setMethods($methods, true, false, true);
   return $fs;
 });

--- a/php/modules/http.php
+++ b/php/modules/http.php
@@ -11,7 +11,7 @@ Module::define('request', function() {
       },
     'getHeaders' => function() use (&$SERVER, &$headers) {
         if ($headers === null) {
-          $headers = new Object();
+          $headers = new ObjectClass();
           foreach ($SERVER as $key => $value) {
             if (substr($key, 0, 5) === 'HTTP_') {
               $key = strtolower(substr($key, 5));
@@ -32,7 +32,7 @@ Module::define('request', function() {
         }
         if (feof($self->stream)) {
           fclose($self->stream);
-          return Object::$null;
+          return ObjectClass::$null;
         }
         return new Buffer(fread($self->stream, $bytes));
       },
@@ -41,7 +41,7 @@ Module::define('request', function() {
         return new Buffer($data);
       }
   );
-  $request = new Object();
+  $request = new ObjectClass();
   $request->setMethods($methods, true, false, true);
   return $request;
 });
@@ -72,7 +72,7 @@ Module::define('response', function() {
         exit();
       }
   );
-  $response = new Object();
+  $response = new ObjectClass();
   $response->setMethods($methods, true, false, true);
   return $response;
 });

--- a/runtime.php
+++ b/runtime.php
@@ -6,7 +6,7 @@ error_reporting(E_ALL);
 require_once('php/helpers/operators.php');
 require_once('php/helpers/helpers.php');
 
-require_once('php/classes/Object.php');
+require_once('php/classes/ObjectClass.php');
 require_once('php/classes/Function.php');
 require_once('php/classes/Global.php');
 require_once('php/classes/Array.php');

--- a/test/transforms.txt
+++ b/test/transforms.txt
@@ -323,7 +323,7 @@ $f = new Func("f", function() {
 ----
 a = {a: 1, undefined: undefined, null: null};
 ====
-$a = new Object("a", 1.0, "undefined", $undefined, "null", Object::$null);
+$a = new ObjectClass("a", 1.0, "undefined", $undefined, "null", ObjectClass::$null);
 
 ----
 undefined = 1;
@@ -352,7 +352,7 @@ $«24» = new Func("\$", function() {
 ----
 var a = [1, false, null, undefined, new Date(), a];
 ====
-$a = new Arr(1.0, false, Object::$null, $undefined, _new($Date), $a);
+$a = new Arr(1.0, false, ObjectClass::$null, $undefined, _new($Date), $a);
 
 ----
 var a = function a() {
@@ -400,7 +400,7 @@ call_method($r, "match", $s);
 call(new Func(function() use (&$process, &$Object) {
   $request = get($process, "request");
   $response = get($process, "response");
-  $resHeaders = new Object("Content-Type", "text/plain");
+  $resHeaders = new ObjectClass("Content-Type", "text/plain");
   call_method($response, "writeHead", 200.0, "OK", $resHeaders);
   call_method($response, "write", _concat(call_method($request, "getMethod"), " ", call_method($request, "getURL"), "\n"));
   $reqHeaders = call_method($request, "getHeaders");

--- a/tests.php
+++ b/tests.php
@@ -20,15 +20,15 @@ Test::suite(
   function() {
     Test::assert(
       'is falsy',
-      is(Object::$null) ? false : true
+      is(ObjectClass::$null) ? false : true
     );
     Test::assert(
       'check typeof',
-      _typeof(Object::$null) === 'object'
+      _typeof(ObjectClass::$null) === 'object'
     );
     Test::assert(
       'check to_string',
-      to_string(Object::$null) === 'null'
+      to_string(ObjectClass::$null) === 'null'
     );
   }
 );
@@ -38,29 +38,29 @@ Test::suite(
   function() {
     Test::assert(
       'props reflect global vars',
-      Object::$global->get('foo') === 'test'
+      ObjectClass::$global->get('foo') === 'test'
     );
-    Object::$global->set('foo', 'test2');
+    ObjectClass::$global->set('foo', 'test2');
     Test::assert(
       'can set global',
-      Object::$global->get('foo') === 'test2'
+      ObjectClass::$global->get('foo') === 'test2'
     );
-    Object::$global->set('foo2', 'bar');
+    ObjectClass::$global->set('foo2', 'bar');
     Test::assert(
       'can set global which was previously not set',
-      Object::$global->get('foo2') === 'bar'
+      ObjectClass::$global->get('foo2') === 'bar'
     );
     Test::assert(
       'has circular ref',
-      Object::$global->get('global') === Object::$global
+      ObjectClass::$global->get('global') === ObjectClass::$global
     );
     Test::assert(
       'can access escaped vars',
-      Object::$global->get('$') === $GLOBALS['«24»']
+      ObjectClass::$global->get('$') === $GLOBALS['«24»']
     );
     Test::assert(
       'can access escaped vars unicode',
-      Object::$global->get('ür') === 'ür'
+      ObjectClass::$global->get('ür') === 'ür'
     );
   }
 );
@@ -70,15 +70,15 @@ Test::suite(
   function() use ($Object) {
     Test::assert(
       'has method valueOf',
-      Object::$protoObject->get('valueOf') instanceof Func
+      ObjectClass::$protoObject->get('valueOf') instanceof Func
     );
     Test::assert(
       '__proto__ is null',
-      Object::$protoObject->proto === Object::$null
+      ObjectClass::$protoObject->proto === ObjectClass::$null
     );
     Test::assert(
       'check toString',
-      $Object->get('prototype')->get('toString') === Object::$protoObject->get('toString')
+      $Object->get('prototype')->get('toString') === ObjectClass::$protoObject->get('toString')
     );
   }
 );
@@ -103,7 +103,7 @@ Test::suite(
 Test::suite(
   'Object',
   function() use ($Object) {
-    $o = new Object("a", 1.0, "b", 2.0);
+    $o = new ObjectClass("a", 1.0, "b", 2.0);
     Test::assert(
       'data present',
       join(',', array_keys($o->data)) === 'a,b'
@@ -130,7 +130,7 @@ Test::suite(
       'keys now two',
       join(',', array_keys($o->data)) === 'a,b'
     );
-    $o = new Object("a", 1.0, "b", 2.0);
+    $o = new ObjectClass("a", 1.0, "b", 2.0);
     Test::assert(
       'for..in helper',
       join(',', keys($o)) === 'a,b'
@@ -157,9 +157,9 @@ Test::suite(
   function() use ($Array) {
     $arr = $Array->construct();
     $arr->set(0.0, 'a');
-    Test::assert('proto exists', $arr->proto instanceof Object);
+    Test::assert('proto exists', $arr->proto instanceof ObjectClass);
     Test::assert('proto is set correctly', $arr->proto === $Array->get('prototype'));
-    Test::assert('proto chain', $arr->proto->proto === Object::$protoObject);
+    Test::assert('proto chain', $arr->proto->proto === ObjectClass::$protoObject);
     Test::assert('is_int length', is_int($arr->length));
     $arr->remove('0');
     Test::assert('length', $arr->get('length') === 1.0);
@@ -214,10 +214,10 @@ Test::suite(
       $arguments = Func::getArguments();
       Test::assert('arguments', $arguments instanceof Args);
       Test::assert('arguments.callee', $arguments->get('callee') === $fn);
-      Test::assert('arguments is object', $arguments instanceof Object);
+      Test::assert('arguments is object', $arguments instanceof ObjectClass);
       Test::assert('arguments is not array', !($arguments instanceof Arr));
       Test::assert('arguments has length', $arguments->get('length') === 0.0);
-      Test::assert('this is global', $self === Object::$global);
+      Test::assert('this is global', $self === ObjectClass::$global);
     });
     $fn->call();
     $fn = new Func('foo', function() use ($fn, $Array) {
@@ -276,11 +276,11 @@ Test::suite(
   function() use ($Object) {
     $obj = $Object->construct();
     $obj->set('a', 1.0);
-    $descriptor = new Object('enumerable', false);
+    $descriptor = new ObjectClass('enumerable', false);
     $Object->callMethod('defineProperty', $obj, 'foo', $descriptor);
     $keys = $Object->callMethod('keys', $obj);
     Test::assert('key is not enumerable', $keys->callMethod('toString') === 'a');
-    $props = new Object('bar', $descriptor, 'baz', $descriptor);
+    $props = new ObjectClass('bar', $descriptor, 'baz', $descriptor);
     $Object->callMethod('defineProperties', $obj, $props);
     $keys = $Object->callMethod('keys', $obj);
     Test::assert('defineProperties worked', $keys->callMethod('toString') === 'a');

--- a/tools/codegen.js
+++ b/tools/codegen.js
@@ -380,7 +380,7 @@
         items.push(encodeString(keyName));
         items.push(this.generate(node.value));
       }, this);
-      return 'new Object(' + items.join(', ') + ')';
+      return 'new ObjectClass(' + items.join(', ') + ')';
     },
 
     CallExpression: function(node) {
@@ -782,7 +782,7 @@
       return 'null';
     }
     if (type === 'null') {
-      return 'Object::$null';
+      return 'ObjectClass::$null';
     }
     if (type === 'string') {
       return encodeString(value);


### PR DESCRIPTION
Rename class 'Object' into 'ObjectClass' because Object is a reserved word in PHP >= 7.2. Fixes #6.