### PR TITLE
Preserve non-base10 numeric literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "escope": "^1.0.1",
-    "esprima": "^1.2.2",
-    "rocambole": "^0.3.6",
+    "rocambole": "^0.7.0",
     "yargs": "^1.3.2"
   },
   "devDependencies": {},

--- a/test/number.js
+++ b/test/number.js
@@ -39,4 +39,11 @@ testSuite('numbers', function(assert) {
     assert("str - 1", isNaN('x' - 1));
   });
 
+  testSuite('numeric literals', function() {
+    assert('0xFFF === 4095', 0xFFF === 4095);
+    assert('0123 === 83', 0123 === 83);
+    assert('0o123 === 83', 0o123 === 83);
+    assert('0b111 === 7', 0b111 === 7);
+  });
+
 });

--- a/test/transforms.txt
+++ b/test/transforms.txt
@@ -304,9 +304,9 @@ assert(e === true);
 $e = true;
 try {
   throw new Ex(_new($Error, "foo"));
-} catch(Exception $e_1_) {
-  if ($e_1_ instanceof Ex) $e_1_ = $e_1_->value;
-  call($assert, _instanceof($e_1_, $Error));
+} catch(Exception $e_2_) {
+  if ($e_2_ instanceof Ex) $e_2_ = $e_2_->value;
+  call($assert, _instanceof($e_2_, $Error));
 }
 call($assert, $e === true);
 
@@ -409,3 +409,23 @@ call(new Func(function() use (&$process, &$Object) {
   }));
   call_method($response, "end");
 }));
+----
+a = 0xFFF;
+====
+$a = (float)0xFFF;
+
+----
+a = 0123;
+====
+$a = (float)0123;
+
+----
+a = 0o123;
+====
+$a = (float)0123;
+
+----
+a = 0b101;
+====
+$a = (float)0b101;
+

--- a/tools/codegen.js
+++ b/tools/codegen.js
@@ -796,8 +796,8 @@
         && node.raw.startsWith('0')) {
       // Preserve numeric literals (e.g. 0xD800)
       // Replace octal prefix because '0o' is not allowed in PHP
-      var value = node.raw.replace(/^0o/, '0');
-      return '(float)' + value;
+      var rawValue = node.raw.replace(/^0o/, '0');
+      return '(float)' + rawValue;
     }
     if (type === 'number') {
       value = value.toString();

--- a/tools/codegen.js
+++ b/tools/codegen.js
@@ -792,16 +792,11 @@
     }
     if (type === 'number'
         && node
-        && node.startToken
-        && node.startToken.type === 'Numeric'
-        && node.startToken.value.length > 1
-        && node.startToken.value.startsWith('0')) {
-        // preserve numeric literals (e.g. 0xD800)
-      var value = node.startToken.value;
-      if (value.startsWith('0o')) {
-        // Replace octal prefix '0o' with '0' because '0o' is not allowed in PHP
-        value = '0' + value.substr(2);
-      }
+        && node.raw.length > 1
+        && node.raw.startsWith('0')) {
+      // Preserve numeric literals (e.g. 0xD800)
+      // Replace octal prefix because '0o' is not allowed in PHP
+      var value = node.raw.replace(/^0o/, '0');
       return '(float)' + value;
     }
     if (type === 'number') {

--- a/tools/codegen.js
+++ b/tools/codegen.js
@@ -546,7 +546,7 @@
       }
       //special case here: -3 is just a number literal, not negate(3)
       if (op === '-' && node.argument.type === 'Literal' && typeof node.argument.value === 'number') {
-        return '-' + encodeLiteral(node.argument.value);
+        return '-' + encodeLiteral(node.argument.value, node.argument);
       }
       //special case here: `typeof a` can be called on a non-declared variable
       if (op === 'typeof' && node.argument.type === 'Identifier') {
@@ -675,7 +675,7 @@
 
         //EXPRESSIONS
         case 'Literal':
-          result = encodeLiteral(node.value);
+          result = encodeLiteral(node.value, node);
           break;
         case 'Identifier':
           result = encodeVar(node);
@@ -776,7 +776,7 @@
   }
 
 
-  function encodeLiteral(value) {
+  function encodeLiteral(value, node) {
     var type = (value === null) ? 'null' : typeof value;
     if (type === 'undefined') {
       return 'null';
@@ -789,6 +789,20 @@
     }
     if (type === 'boolean') {
       return value.toString();
+    }
+    if (type === 'number'
+        && node
+        && node.startToken
+        && node.startToken.type === 'Numeric'
+        && node.startToken.value.length > 1
+        && node.startToken.value.startsWith('0')) {
+        // preserve numeric literals (e.g. 0xD800)
+      var value = node.startToken.value;
+      if (value.startsWith('0o')) {
+        // Replace octal prefix '0o' with '0' because '0o' is not allowed in PHP
+        value = '0' + value.substr(2);
+      }
+      return '(float)' + value;
     }
     if (type === 'number') {
       value = value.toString();


### PR DESCRIPTION
 - Preserve numerical literals if they start with 0 (like 0x..., 0b..., 0o...)
- Update dependency rocambole to latest version (0.7.0) and remove esprima which is transitively included by rocambole. Update was necessary because old esprima version was not able to handle octal and binary numeric literals.

Fixes #9 